### PR TITLE
Add support for pre-release and build metadata labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ console.log(nodeVersion.major, nodeVersion.minor, nodeVersion.patch);
 
 ### parseVersion(nodeVersionString)
 
-Takes a node version string (usually `process.version`) and returns an object with the `major`, `minor`, and `patch` keys which will all be parsed digits.
+Takes a node version string (usually `process.version`) and returns an object with the `major`, `minor`, and `patch` keys which will all be parsed digits. If available, the pre-release and build metadata labels are also returned with the 'preRelease' and 'buildMetadata' keys respectively.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
 'use strict';
 
 function parseNodeVersion(version) {
-  var match = version.match(/^v(\d{1,2})\.(\d{1,2})\.(\d{1,2})$/);
+  var match = version.match(/^v(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:-([0-9A-Za-z-.]+))?(?:\+([0-9A-Za-z-.]+))?$/); // eslint-disable-line max-len
   if (!match) {
     throw new Error('Unable to parse: ' + version);
   }
 
-  return {
+  var res = {
     major: parseInt(match[1], 10),
     minor: parseInt(match[2], 10),
     patch: parseInt(match[3], 10),
   };
+  if (match[4] !== undefined) {
+    res.preRelease = match[4];
+  }
+  if (match[5] !== undefined) {
+    res.buildMetadata = match[5];
+  }
+  return res;
 }
 
 module.exports = parseNodeVersion;

--- a/test/index.js
+++ b/test/index.js
@@ -48,4 +48,41 @@ describe('parseNodeVersion', function() {
     expect(invalid).toThrow('Unable to parse: v8.111.8');
     done();
   });
+
+  it('matches pre-release label with single identifier', function(done) {
+    var nodeVersion = parseNodeVersion('v1.2.3-alpha');
+    expect(nodeVersion.major).toEqual(1);
+    expect(nodeVersion.minor).toEqual(2);
+    expect(nodeVersion.patch).toEqual(3);
+    expect(nodeVersion.preRelease).toEqual('alpha');
+    done();
+  });
+
+  it('matches pre-release label with multiple identifiers', function(done) {
+    var nodeVersion = parseNodeVersion('v1.2.3-x.7.z.92');
+    expect(nodeVersion.major).toEqual(1);
+    expect(nodeVersion.minor).toEqual(2);
+    expect(nodeVersion.patch).toEqual(3);
+    expect(nodeVersion.preRelease).toEqual('x.7.z.92');
+    done();
+  });
+
+  it('matches build metadata', function(done) {
+    var nodeVersion = parseNodeVersion('v10.15.0+0-b20181231T20014594');
+    expect(nodeVersion.major).toEqual(10);
+    expect(nodeVersion.minor).toEqual(15);
+    expect(nodeVersion.patch).toEqual(0);
+    expect(nodeVersion.buildMetadata).toEqual('0-b20181231T20014594');
+    done();
+  });
+
+  it('matches pre-release label and build metadata', function(done) {
+    var nodeVersion = parseNodeVersion('v1.0.0-beta+exp.sha.5114f85');
+    expect(nodeVersion.major).toEqual(1);
+    expect(nodeVersion.minor).toEqual(0);
+    expect(nodeVersion.patch).toEqual(0);
+    expect(nodeVersion.preRelease).toEqual('beta');
+    expect(nodeVersion.buildMetadata).toEqual('exp.sha.5114f85');
+    done();
+  });
 });


### PR DESCRIPTION
Address issue #3. parse-node-version is currently unable to parse the version string of node when it's built with the --tag option set which contains a pre-release label and/or build metadata as per semver.org.